### PR TITLE
Preventing Click Jacking

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -3,6 +3,7 @@
 	<title>{% if page.title %}{{ page.title }} |{% endif %} {{ site.theme.title }}</title>
 	<meta name="description" content="{% if page.excerpt %}{{ page.excerpt | strip_html | strip_newlines | truncate: 160 }}{% else %}{{ site.theme.description }}{% endif %}">
 	<meta name="viewport" content="width=device-width, initial-scale=1">
+	<meta http-equiv="X-Frame-Options" content="sameorigin">
 	
 	<!-- CSS -->
 	<link rel="stylesheet" href="{{ "/css/main.css" | prepend: site.baseurl }}">


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Clickjacking

The meta tag should take care of most cases. Legacy browsers might need a workaround.